### PR TITLE
feat: trigger PlatformMesh OCM build if any of the references are updated

### DIFF
--- a/.github/workflows/job-ocm.yml
+++ b/.github/workflows/job-ocm.yml
@@ -115,3 +115,8 @@ jobs:
             LOCAL_CHART_PATH=${{ inputs.chartPath }}
       - name: Transfer to OCM REPO
         run: ./ocm transfer ctf --overwrite .ocm/transport.ctf "${{ inputs.ocmRegistryUrl }}"
+      - name: Trigger PlatformMesh OCM build
+        run: |
+          gh workflow run ocm.yaml --repo "platform-mesh/ocm"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This pull request introduces an improvement to the OCM workflow by automating the triggering of a PlatformMesh OCM build after transferring to the OCM repository.

Workflow automation:

* Added a new step in `.github/workflows/job-ocm.yml` to trigger the PlatformMesh OCM build by running the `ocm.yaml` workflow in the `platform-mesh/ocm` repository using the GitHub CLI.