### PR TITLE
feat: forward serviceComponentConstructorFile to service component pipeline

### DIFF
--- a/.github/workflows/job-ocm.yml
+++ b/.github/workflows/job-ocm.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: ''
+      serviceComponentConstructorFile:
+        description: "Custom service component constructor file in the ocm repo (defaults to constructor/service-component.yaml)"
+        required: false
+        type: string
+        default: ''
 
 jobs:
   ocm:
@@ -182,9 +187,11 @@ jobs:
             -f chartName="${{ env.CHART_NAME }}" \
             -f chartVersion="${{ env.VERSION }}" \
             -f appVersion="${{ env.APP_VERSION }}" \
-            -f imageComponentName="$IMAGE_COMPONENT_NAME"
+            -f imageComponentName="$IMAGE_COMPONENT_NAME" \
+            ${SERVICE_COMPONENT_CONSTRUCTOR_FILE:+-f componentConstructorFile="$SERVICE_COMPONENT_CONSTRUCTOR_FILE"}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          SERVICE_COMPONENT_CONSTRUCTOR_FILE: ${{ inputs.serviceComponentConstructorFile }}
 
       - name: Trigger PlatformMesh OCM build (monolithic mode)
         if: ${{ inputs.chartOnly != true }}


### PR DESCRIPTION
## Summary

- Adds optional `serviceComponentConstructorFile` input to `job-ocm.yml`
- When set, forwards it as `componentConstructorFile` to the `pipeline-service-component.yml` dispatch in the ocm repo
- When empty (default), the ocm repo's default constructor (`constructor/service-component.yaml`) is used

Depends on platform-mesh/ocm#90. Follow-up PR in platform-mesh/helm-charts will use this to pass a custom constructor for the example-httpbin-operator.