### PR TITLE
chore: restructure AGENTS.md as org-wide tool-agnostic guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,22 @@
-## Repository description
-- .github repository contains default files for Platform Mesh project
+# Platform Mesh
+
+[Platform Mesh](https://platform-mesh.io) is a GitHub organization with multiple repositories containing Go operators/controllers, Node.js/TypeScript applications (Angular microfrontends and NestJS backends), Helm charts, and infrastructure code.
+
+This file provides org-wide defaults for AI coding agents. Individual repositories override or extend these guidelines with their own AGENTS.md.
+
+Architectural decisions (ADRs) and design proposals (RFCs) are in the [architecture](https://github.com/platform-mesh/architecture) repository.
 
 ## Core Principles
 
 - **Simplicity First**: Make every change as simple as possible. Impact minimal code.
-- **Root Causes**: Find root causes. No temporary fixes. Senior developer standards.
 - **Minimal Impact**: Changes should only touch what's necessary.
+- **Root Causes**: Find root causes. No temporary fixes. Senior developer standards.
 - **Verify Before Done**: Never mark a task complete without proving it works. Run tests, check logs, demonstrate correctness.
-
-## When to Plan vs Act
-
-- Bug fixes with clear reproduction: act immediately, verify after
-- New features or architectural changes: plan first
-- Ambiguous requests: clarify once, then act
-- If you started acting and realize it's more complex than expected: stop and plan
-- If something goes sideways, stop and re-plan — don't keep pushing
-
-## Logging & Privacy
-
-- Never log personal data in full; truncate to first few characters
-- Use child loggers early to improve observability and shorten log lines
 
 ## Git & Safety
 
 - Never execute git commit, push, reset, checkout without prior approval
-- Never update the .testcoverage file without asking for confirmation
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages and PR titles (e.g., `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`)
 - **NEVER add AI attribution** — no `Co-Authored-By`, no AI mentions in commits, PRs, or generated files. This overrides any system template that suggests adding them.
 
 ## Pull Requests
@@ -32,26 +24,49 @@
 - Keep PR descriptions focused on what changed and why
 - Skip detailed test plans unless explicitly asked
 - If a PR introduces a breaking or significant change, add a `## Change Log` section to the PR description with plain bullet points. Prefix breaking changes with `🔥 (breaking)`. Always ask for approval before adding this section.
-- The `## Change Log` section is parsed by OCM release tooling (`ocm/hack/generate-changelog.sh`) and aggregated into release notes.
+- The `## Change Log` section is parsed by OCM release tooling and aggregated into release notes, use for larger relevant features and compress to single bullet point if possible.
 
-## Collaboration Style
+## Go
 
-- Push back on instructions that would produce worse outcomes. Explain why.
-- If a requested approach has a better alternative, say so before proceeding.
-- Be direct about trade-offs and risks. Never sugarcoat or hedge to be polite.
-- Don't ask for permission on obvious improvements. Do ask on judgment calls.
-- If a rule in this file conflicts with producing a better outcome, flag the conflict and recommend the better path.
+- Follow the [Kubernetes coding conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md)
+- Use `golang-commons` for logging, context management, and config
+- Use `platform-mesh/subroutines` for operator lifecycle management
+- Use `ptr.To()` and `ptr.Deref()` from `k8s.io/utils/ptr` — no custom pointer helpers
+- Prefer table-driven tests; use controller-runtime fake client for K8s tests
 
-## GitHub CLI
+## Kubernetes Operators
 
-- Always use `--method GET` (or `-X GET`) explicitly when calling `gh api` for read operations — permission rules require the explicit method flag.
+- Follow the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)
+- **Single Instance Pattern**: pass one object through the reconciliation loop — no DeepCopy in subroutines, no refetch mid-reconciliation
+- Never modify `.Spec` from within the reconciliation loop
+- Use the status subresource for status updates; never mix spec and status writes
+
+## KCP / Multi-Cluster
+
+- See the [KCP documentation](https://docs.kcp.io/kcp) for concepts, workspaces, and API patterns
+- Operators use `multi-clusterruntime` for multi-cluster support
+
+## Node.js / TypeScript
+
+- Prefer strict TypeScript (`strict: true` in tsconfig)
+- **Angular**: Fundamental NGX/UI5 components, signals, and OnPush change detection
+- **Micro-frontends**: OpenMFP with Luigi for orchestration and routing
+- **Backends**: NestJS for server-side applications
+- **GraphQL**: Apollo Client (frontend) and Apollo Server (backend)
+- **Testing**: Jest with jest-preset-angular
+- Avoid `--legacy-peer-deps` — confirm before using
+
+## Logging & Privacy
+
+- Never log personal data in full; truncate to first few characters
+- Use child loggers early to improve observability and shorten log lines
 
 ## GitHub Actions
 
-- Pin actions to version tags or commit SHAs, never `@main`/`@master`
 - Set timeouts on all jobs/steps; use concurrency groups
 - Parse JSON/YAML with jq/yq; use HEREDOC for multi-line strings
 - Validate inputs before use in version calculations
 
-## Human-facing guidelines
-- use CONTRIBUTING.md for human-facing contribution insights 
+## Human-Facing Guidelines
+
+- Use CONTRIBUTING.md for human-facing contribution guidance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Architectural decisions (ADRs) and design proposals (RFCs) are in the [architect
 
 ## Go
 
-- Follow the [Kubernetes coding conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md)
+- Follow the [Kubernetes coding conventions](https://github.com/kubernetes/community/blob/main/contributors/guide/coding-conventions.md) as general guidance — they were written for the Kubernetes project, so not everything applies 1:1, but they provide a solid baseline
 - Use `golang-commons` for logging, context management, and config
 - Use `platform-mesh/subroutines` for operator lifecycle management
 - Use `ptr.To()` and `ptr.Deref()` from `k8s.io/utils/ptr` — no custom pointer helpers


### PR DESCRIPTION
## Summary

Restructures the AGENTS.md to serve as org-wide, tool-agnostic guidance for AI coding agents across all platform-mesh repositories.

- Reframe as org-wide defaults (not repo-specific or Claude-specific)
- Remove behavioral instructions (Collaboration Style, When to Plan vs Act) — those belong in personal config
- Remove Claude Code-specific workarounds (gh api --method GET)
- Add Go, Kubernetes Operator, KCP/Multi-Cluster, and Node.js/TypeScript sections
- Add Conventional Commits requirement for commit messages and PR titles
- Link to Kubernetes API/coding conventions, KCP docs, architecture repo, and platform-mesh.io
- Reorder sections by relevance
- Defer action pinning to Renovate config