### PR TITLE
feat(ci): add SLSA build provenance attestation to Docker builds

### DIFF
--- a/.github/workflows/job-docker-build-push.yml
+++ b/.github/workflows/job-docker-build-push.yml
@@ -25,6 +25,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      attestations: write
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
@@ -52,6 +53,14 @@ jobs:
       - name: Sign container image
         if: ${{ (github.head_ref || github.ref) == format('refs/heads/{0}',inputs.release_branch) }}
         run: cosign sign --yes ${{ inputs.imageTagName }}@${{ steps.build.outputs.digest }}
+      - name: Attest build provenance
+        if: ${{ (github.head_ref || github.ref) == format('refs/heads/{0}',inputs.release_branch) }}
+        continue-on-error: true # Requires 'attestations: write' in caller workflow permissions
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-name: ${{ inputs.imageTagName }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
       - name: Create Release
         if: ${{ (github.head_ref || github.ref) == format('refs/heads/{0}',inputs.release_branch) }}
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0

--- a/.github/workflows/job-docker-build-push.yml
+++ b/.github/workflows/job-docker-build-push.yml
@@ -55,7 +55,6 @@ jobs:
         run: cosign sign --yes ${{ inputs.imageTagName }}@${{ steps.build.outputs.digest }}
       - name: Attest build provenance
         if: ${{ (github.head_ref || github.ref) == format('refs/heads/{0}',inputs.release_branch) }}
-        continue-on-error: true # Requires 'attestations: write' in caller workflow permissions
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ inputs.imageTagName }}


### PR DESCRIPTION
## Summary

- Adds `actions/attest-build-provenance@v4` to the shared `job-docker-build-push.yml` reusable workflow
- Produces SLSA-compatible build provenance attestations for all container images pushed to GHCR
- Attestation is pushed alongside the image via the OCI referrers API, making it discoverable by policy engines (Kyverno, Gatekeeper, Ratify) and `gh attestation verify`
- Uses `continue-on-error: true` so existing caller pipelines that haven't added `attestations: write` yet won't break

## Follow-up required

Caller workflows (all operator/service pipelines) need to add `attestations: write` to their top-level permissions block for the attestation to succeed. Without it, the step will soft-fail and the image is still built, signed, and pushed as before.

Example change in caller pipelines:
```yaml
permissions:
  contents: write
  id-token: write
  issues: write
  packages: write
  pull-requests: write
  attestations: write  # ← add this
```

## Verification

After a caller adds `attestations: write` and merges a build:
```bash
gh attestation verify oci://ghcr.io/platform-mesh/<repo>/<image>:<tag> --owner platform-mesh
```

Ref: platform-mesh/backlog#229