### PR TITLE
chore: enable daily lock file maintenance

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -123,5 +123,9 @@
       "minimumReleaseAge": "0 days"
     }
   ],
-  "rebaseWhen": "auto"
+  "rebaseWhen": "auto",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am every day"]
+  }
 }


### PR DESCRIPTION
## Summary

- Enables Renovate lock file maintenance on a daily schedule (before 5am) across all org repos
- Renovate will periodically recreate lockfiles from scratch, pulling in latest compatible transitive dependency versions
- This ensures transitive security fixes are picked up automatically, even when direct dependencies haven't released a new version
- Addresses the gap where Renovate couldn't resolve Dependabot security alerts caused by vulnerable transitive dependencies