### PR TITLE
Configure Renovate to handle vulnerabilities as per RFC 007

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "helpers:pinGitHubActionDigests", "docker:pinDigests"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "docker:pinDigests"],
   "npm": {},
   "automerge": true,
   "automergeType": "pr",
@@ -10,6 +10,15 @@
   // Applies globally to all datasources (npm, Docker, Go, Maven, Helm, etc.).
   "minimumReleaseAge": "7 days",
   "platformAutomerge": true,
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security", "vulnerability"],
+    "assignees": ["team:platform-mesh/security"],
+    "reviewers": ["team:platform-mesh/security"],
+    "automerge": true,
+    "platformAutomerge": true
+  },
   "postUpdateOptions": [
     "gomodUpdateImportPaths",
     "gomodTidy",


### PR DESCRIPTION
The RFC's "Option 1" section specifies exactly what changes to make to the Renovate config. The changes based on the RFC's Option 1 requirements are:

- `config:base` → `config:recommended` — the RFC calls for upgrading to the current preset name (they're functionally identical, but config:base is legacy).
- `"osvVulnerabilityAlerts": true` — adds the OSV database as a second vulnerability data source alongside GitHub's advisory database, particularly valuable for Go-specific advisories.
- `"vulnerabilityAlerts"` block — this is the core addition:
  - Labels security and vulnerability for filtering and release note grouping
  - Assignees & reviewers set to team:platform-mesh/security so the security response team is notified immediately
  - Automerge enabled so fixes merge automatically after approval + CI

One important note from the RFC: both `vulnerabilityAlerts` and `osvVulnerabilityAlerts` use Renovate's `force` override internally, so security PRs will bypass the 7-day `minimumReleaseAge`, any `"enabled": false` rules, schedules, and PR limits — the existing dependency management behavior is unaffected.