### PR TITLE
chore: use standard runners for docker build workflow

### DIFF
--- a/.github/workflows/job-docker-build-push.yml
+++ b/.github/workflows/job-docker-build-push.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ${{ (github.head_ref || github.ref) == format('refs/heads/{0}',inputs.release_branch) && 'ubuntu-latest-large' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Summary
- Remove conditional `ubuntu-latest-large` runner from the reusable docker build-and-push workflow
- All docker builds now use `ubuntu-latest` regardless of branch