### PR TITLE
fix(sbom): log into GHCR before syft pull so private images can be scanned

### DIFF
--- a/.github/workflows/job-sbom.yml
+++ b/.github/workflows/job-sbom.yml
@@ -14,6 +14,13 @@ jobs:
       packages: read
     runs-on: ubuntu-latest
     steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:


### PR DESCRIPTION
The anchore/sbom-action `github-token` input is used for GitHub API
calls, not for authenticating the docker pull that syft performs.
For private GHCR packages, syft's anonymous pull fails with 401.

Add docker/login-action as the first step so the runner's docker
daemon has credentials for ghcr.io before syft runs. The workflow
already requests `packages: read`, so the inherited GITHUB_TOKEN
is sufficient.

Mirrors the login pattern already used in job-docker-build-push.yml.

Refs failing run:
https://github.com/platform-mesh/search-operator/actions/runs/24550452517/job/71780497716

On-behalf-of: @SAP mirza.kopic@sap.com
Signed-off-by: Mirza Kopić <mirza.kopic@gmail.com>
