### PR TITLE
fix(ci): align auto-labeler and semver with conventional commit types

### DIFF
--- a/.github/workflows/job-auto-labeler.yml
+++ b/.github/workflows/job-auto-labeler.yml
@@ -30,7 +30,7 @@ jobs:
                 labels: ['BREAKING CHANGE']
               - type: 'documentation'
                 nouns: ['doc', 'docs', 'docu','document','documentation']
-                labels: ['documentation','fix']
+                labels: ['documentation']
               - type: 'ci'
                 nouns: ['build','rebuild','ci']
                 labels: ['ci']
@@ -39,7 +39,13 @@ jobs:
                 labels: ['ci','dependencies']
               - type: 'config'
                 nouns: ['config', 'conf', 'configuration', 'configure']
-                labels: ['config','fix']
+                labels: ['chore']
               - type: 'chore'
-                nouns: ['chore']
-                labels: ['chore','fix']
+                nouns: ['chore', 'test', 'refactor', 'style']
+                labels: ['chore']
+              - type: 'perf'
+                nouns: ['perf']
+                labels: ['enhancement']
+              - type: 'revert'
+                nouns: ['revert']
+                labels: ['fix']

--- a/.github/workflows/job-create-version.yml
+++ b/.github/workflows/job-create-version.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           majorList: BREAKING CHANGE, BREAKING, MAJOR
           minorList: FEATURE, Feature, feature, FEAT, Feat, feat
-          patchList: FIX, Fix, fix, FIXED, Fixed, fixed, chore, config, conf, cofiguration, configure, build, chore, ci, rebuild, doc, docu, document, documentation, dependencies
+          patchList: FIX, Fix, fix, FIXED, Fixed, fixed, chore, config, conf, cofiguration, configure, build, chore, ci, rebuild, doc, docu, document, documentation, dependencies, test, refactor, perf, style, revert
           noNewCommitBehavior: patch
           noVersionBumpBehavior: patch
           skipInvalidTags: true


### PR DESCRIPTION
## Summary

- Add missing conventional commit types (`test`, `refactor`, `style`, `perf`, `revert`) to auto-labeler nouns and semver `patchList` — commits with these prefixes were previously unrecognized
- Remove spurious `fix` label from `documentation`, `config`, and `chore` types — a docs or config change is not a fix
- Map new types to existing labels to avoid creating new labels across all repos: `test`/`refactor`/`style`/`config` → `chore`, `perf` → `enhancement`, `revert` → `fix`