### PR TITLE
Add reusable Trivy image scanning workflow

### DIFF
--- a/.github/workflows/job-sbom.yml
+++ b/.github/workflows/job-sbom.yml
@@ -6,12 +6,17 @@ on:
         description: "Full image reference (e.g., ghcr.io/platform-mesh/security-operator:1.2.3)"
         required: true
         type: string
+      vulnScanSeverity:
+        description: 'Severity levels to scan for (default: CRITICAL,HIGH)'
+        type: string
+        default: 'CRITICAL,HIGH'
 
 jobs:
   sbom:
     permissions:
       contents: read
       packages: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
@@ -45,3 +50,23 @@ jobs:
             sbom-cyclonedx.json
             sbom-spdx.json
           retention-days: 1
+
+      - name: Run Trivy vulnerability scanner
+        if: inputs.vulnScanSeverity != ''
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'sbom'
+          scan-ref: 'sbom-cyclonedx.json'
+          severity: ${{ inputs.vulnScanSeverity }}
+          ignore-unfixed: true
+          exit-code: '0' # Do not block on vulnerabilities, just report them
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        # if vulnScanSecurity is set and previous action generated a SAREF file
+        if: inputs.vulnScanSeverity != '' && hashFiles('trivy-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a # v2.25.4
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-sbom-scan'

--- a/.github/workflows/job-trivy-image.yml
+++ b/.github/workflows/job-trivy-image.yml
@@ -1,0 +1,40 @@
+name: Container Security Scan
+on:
+  workflow_call:
+    inputs:
+      imageRef:
+        description: 'Full image reference to scan (e.g. ghcr.io/platform-mesh/security-operator:1.2.3)'
+        required: true
+        type: string
+      severity:
+        description: 'Severity levels to scan for (default: CRITICAL,HIGH)'
+        type: string
+        default: 'CRITICAL,HIGH'
+      exitCode:
+        description: 'Exit code to use if vulnerabilities are found (default: 0 - do not fail the workflow)'
+        type: string
+        default: '0'
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: ${{ inputs.imageRef }}
+          severity: ${{ inputs.severity }}
+          exit-code: ${{ inputs.exitCode }}
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a # v2.25.4
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-sbom-scan.yml
+++ b/.github/workflows/trivy-sbom-scan.yml
@@ -1,0 +1,123 @@
+name: Rescan SBOMs for Recent Component Versions
+
+on:
+  workflow_call:
+    inputs:
+      component:
+        description: 'OCM component name (defaults to github.com/{org}/images/{repo})'
+        default: ''
+        type: string
+      repo:
+        description: 'OCI registry repo (defaults to ghcr.io/{org})'
+        default: ''
+        type: string
+      releaseCount:
+        default: '1'
+        type: string
+      severity:
+        default: 'CRITICAL,HIGH'
+        type: string
+    secrets:
+      registryToken:
+        required: false
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+env:
+  COMPONENT: ${{ inputs.component || format('github.com/{0}/images/{1}', github.repository_owner, github.event.repository.name) }}
+  REPO: ${{ inputs.repo || format('ghcr.io/{0}', github.repository_owner) }}
+  RELEASE_COUNT: ${{ inputs.releaseCount }}
+  REGISTRY_TOKEN: ${{ secrets.registryToken || secrets.GITHUB_TOKEN }}
+
+jobs:
+  list-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.fetch.outputs.versions }}
+    steps:
+      - name: Install ocm
+        run: |
+          curl -sSL https://ocm.software/install.sh | sudo bash
+
+      - name: Log in to registry
+        run: |
+          REGISTRY_HOST="${REPO%%/*}"
+          echo "${REGISTRY_TOKEN}" | \
+            oras login "$REGISTRY_HOST" -u "${{ github.actor }}" --password-stdin
+
+      - name: List recent component versions
+        id: fetch
+        run: |
+          versions=$(ocm get cv "$REPO//$COMPONENT" -o json \
+            | jq -r '.[].component.version' \
+            | sort -V -r \
+            | head -n "$RELEASE_COUNT" \
+            | jq -R . | jq -s -c .)
+          echo "versions=${versions}" >> "$GITHUB_OUTPUT"
+          echo "Will rescan: ${versions}"
+
+  scan-sboms:
+    needs: list-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJson(needs.list-versions.outputs.versions) }}
+    steps:
+      - name: Install ocm and oras
+        run: |
+          curl -sSL https://ocm.software/install.sh | sudo bash
+          curl -sSL "https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin oras
+
+      - name: Log in to registry
+        run: |
+          REGISTRY_HOST="${REPO%%/*}"
+          echo "${REGISTRY_TOKEN}" | \
+            oras login "$REGISTRY_HOST" -u "${{ github.actor }}" --password-stdin
+
+      - name: Fetch SBOM for ${{ matrix.version }}
+        run: |
+          DIGEST=$(ocm get cv "$REPO//$COMPONENT:${{ matrix.version }}" -o yaml \
+            | yq '.[].component.resources[] | select(.name == "sbom-cyclonedx") | .access.localReference')
+
+          if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+            echo "No SBOM resource found for ${{ matrix.version }}"
+            exit 1
+          fi
+
+          oras blob fetch \
+            --output "sbom-${{ matrix.version }}.json" \
+            "$REPO/component-descriptors/$COMPONENT@$DIGEST"
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'sbom'
+          scan-ref: 'sbom-${{ matrix.version }}.json'
+          severity: ${{ inputs.severity }}
+          ignore-unfixed: true
+          exit-code: '0' # Do not block on vulnerabilities, just report them
+          format: 'sarif'
+          output: 'trivy-${{ matrix.version }}.sarif'
+
+      - name: Resolve tag to SHA
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha=$(gh api "/repos/${{ github.repository }}/git/refs/tags/${{ matrix.version }}" \
+            --jq '.object.sha' 2>/dev/null || echo "")
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: hashFiles(format('trivy-{0}.sarif', matrix.version)) != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-${{ matrix.version }}.sarif'
+          category: 'trivy-sbom-release-scan'
+          ref: 'refs/tags/${{ matrix.version }}'
+          sha: ${{ steps.resolve.outputs.sha }}


### PR DESCRIPTION
## Summary

Adds SBOM-based vulnerability scanning with Trivy to our CI, covering both newly built images and historical releases. Scans run against the SBOMs we already generate at build time (in CycloneDX format), and results are uploaded to the GitHub Security tab.

Additionally, a workflow based on scanning images is provided for repositories that don't bulid SBOMs.

## Why

First of all, Dependabot Alerts and Renovate already inform us about vulnerability in dependencies on the main branch. What they don't see are vulnerabilities in the container image — OS packages and `RUN`-installed tooling. Trivy now fills that gap.

What's maybe more important is that SBOM-based scanning with Trivy allows us to scan existing SBOM files, i.e. scan for vulnerabilities in the existing releases. A workflow for that is provided in this PR as well. The workflow searchs for past N releases, downloads their SBOMs, and runs Trivy on those SBOMs. Results are uploaded to the GitHub Security tab. Important to note, this is a reusable workflow, it must be implemented in each relevant repo.

It's also important to note that there will be some overlap between Trivy and Dependabot Alerts/Renovate. Since scanning is based on SBOMs, Trivy will also report vulnerabilities covered by Dependabot Alerts and Renovate. This can generate some additional noise, but hopefully nothing significant.

At the moment, Trivy is configured to report critical and high rated vulnerabilities. This can be extended to all vulnerabilities once we're happy with how Trivy works and integrates in our CI.

## What's included

**`job-trivy-image.yml`** — reusable workflow that scans a built image and uploads SARIF to Code scanning. Takes the image reference, severity filter, and exit code as inputs. Findings are reported but don't fail the build by default.

**`job-sbom.yml`** — extends the existing SBOM generation job with an optional Trivy scan of the generated CycloneDX SBOM, gated by the `vulnScanSeverity` input so consumers can opt in.

**`trivy-sbom-scan.yml`** — reusable workflow for periodically rescanning SBOMs of recent component versions pulled from OCM/GHCR. The `releaseCount` input controls how many recent versions to check. `component` and `repo` default to `github.com/{org}/images/{repo}` and `ghcr.io/{org}` respectively, so most consumers don't need to set them.

cc @nexus49 @aaronschweig @mirzakopic