### PR TITLE
chore: dont trust internal shared workflows

### DIFF
--- a/.github/workflows/job-check-helm-chart-docs.yml
+++ b/.github/workflows/job-check-helm-chart-docs.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -107,10 +107,10 @@
       "platformAutomerge": false
     },
     {
-      "description": "Trust our own org workflows — follow branch refs without digest pinning",
-      "matchPackagePatterns": ["^platform-mesh/"],
+      "description": "No release delay for our own reusable workflows and org Actions",
       "matchManagers": ["github-actions"],
-      "pinDigests": false
+      "matchPackagePatterns": ["^platform-mesh/"],
+      "minimumReleaseAge": "0 days"
     },
     {
       "groupName": "Github Actions",


### PR DESCRIPTION
Pinning these dependencies to main substantially lowers the Pinned-Dependencies OpenSSF scorecard check